### PR TITLE
lsコマンドを作る Part2 -aオプションの追加

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -4,12 +4,18 @@ class LS
   # 出力時の最大横列数
   MAX_WIDTH = 3
 
-  def initialize(path)
+  def initialize(path, options)
     path ||= './'
     inspect_path(path) unless path == './'
-    @files = Dir.children(path)
-    execute_file_effector
-    print_files
+    @files = Dir.entries(path).sort!
+    @options = options
+    init_files
+  end
+
+  def print_files
+    insert_space_into_file_name
+    records = init_records
+    records.each { |record| puts record.join("\t") }
   end
 
   private
@@ -26,11 +32,9 @@ class LS
     exit
   end
 
-  # 取得した配列の操作
-  def execute_file_effector
-    insert_space_into_file_name
-    excludes_secret
-    sorts
+  # オプションの判定
+  def init_files
+    @options[:a] ? @files : excludes_secret
   end
 
   # 隠しファイルを配列から削除
@@ -38,18 +42,9 @@ class LS
     @files.reject! { |f| f.start_with?('.') }
   end
 
-  def sorts
-    @files.sort!
-  end
-
   # 空白を挿入してファイル名を20文字に統一
   def insert_space_into_file_name
     @files.map! { |file| file.ljust(20) }
-  end
-
-  # ファイル表示の際の横列数
-  def column_num
-    (@files.size.to_f / MAX_WIDTH).ceil
   end
 
   # 横1列に表示されるファイルを格納した配列を要素に持つ配列
@@ -59,8 +54,8 @@ class LS
     end
   end
 
-  def print_files
-    records = init_records
-    records.each { |record| puts record.join("\t") }
+  # ファイル表示の際の横列数
+  def column_num
+    (@files.size.to_f / MAX_WIDTH).ceil
   end
 end

--- a/05.ls/main.rb
+++ b/05.ls/main.rb
@@ -3,5 +3,8 @@
 # frozen_string_literal: true
 
 require_relative 'ls'
+require_relative 'option'
 
-LS.new(ARGV[0])
+opt = Option.new
+ls = LS.new(ARGV[0], opt.options)
+ls.print_files

--- a/05.ls/option.rb
+++ b/05.ls/option.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+class Option
+  OPTIONS = %w[a].freeze
+
+  attr_reader :options
+
+  def initialize
+    @opt = OptionParser.new
+    @options = {}
+    init_options
+    @opt.parse!(ARGV, into: @options)
+  end
+
+  private
+
+  def init_options
+    OPTIONS.each { |opt| @opt.on("-#{opt}") }
+  end
+end


### PR DESCRIPTION
## What
前回の課題、`ls`コマンドに`-a`オプションの追加。

## Why
課題提出のため。

## How
- オプション登録用のOptionクラスを作成
- LSクラスの初期化時にオプションクラスのインスタンス変数を渡す
- 受け取ったオプションを元に`init_files`メソッドで表示するファイルの操作
- ファイル表示用メソッド`print_files`を初期化時の実行ではなく外から呼び出す方針へ変更

## 課題点、疑問点
### Optionクラスのインスタンス変数`@options`に関して`Hash`にする必要がない気がしている🤔
引数として渡した先のクラスでオプション毎にフラグがついていた方が制御しやすいかなと考えこの実装にしましたが、そもそも各キーの値が`false`になることはないので、配列として管理しても良いかもと思いました。
